### PR TITLE
fix: make TCP_activity compatible with network shims

### DIFF
--- a/source/usr/local/emhttp/plugins/dynamix.s3.sleep/scripts/s3_sleep
+++ b/source/usr/local/emhttp/plugins/dynamix.s3.sleep/scripts/s3_sleep
@@ -250,7 +250,7 @@ HDD_activity() {
 }
 
 txrx_bytes() {
-  echo $(awk "/$eth:/{print \$2+\$10}" /proc/net/dev)
+  echo $(awk "/ $eth:/{print \$2+\$10}" /proc/net/dev)
 }
 
 TCP_activity() {


### PR DESCRIPTION
To make the packet counter compatible with a network shim.

Example stats from my server:

Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
    lo: 23215246665 136083215    0    0    0     0          0         0 23215246665 136083215    0    0    0     0       0          0
 tunl0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
  eth0:   80900     715    0 1896322 4584     0          0   7487276     1016      11    0    0    0     0       0          0
  eth1:  327173    1439    0 1892490  796     0          0   7578469   195530    1028    0    0    0     0       0          0
docker_gwbridge:       0       0    0    0    0     0          0         0    19149     101    0    0    0     0       0          0
br-eeb6142465d9:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
docker0: 512408027 3929432    0    0    0     0          0         0 2758322741 3992939    0    0    0     0       0          0
shim-eth1: 620460735509 105416457    0 1891416    0     0          0  26996174 28413473825 58713054    0 2318    0     0       0          0
vethe79bd6f: 9153717    5600    0    0    0     0          0         0  3839576   31986    0    0    0     0       0          0
veth90fd6b5: 540896672 3713762    0    0    0     0          0         0 1903549320 3605271    0    0    0     0       0          0
